### PR TITLE
Type import

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
 import { App, defineAsyncComponent } from 'vue';
-import { Prop } from './type';
+import type { Prop } from './type';
 
 export { Prop };
 


### PR DESCRIPTION
type keyword is necessary otherwise TS will give a warning that prop was not found.